### PR TITLE
Add "cascade" to "truncate"

### DIFF
--- a/lib/datasets.js
+++ b/lib/datasets.js
@@ -69,6 +69,7 @@ const datasets = {
       // Construct query to truncate all tables
       let _queryToExecute = 'TRUNCATE TABLE '
       _queryToExecute += rows.map(elem => `"${elem.table_name}"`).join(', ')
+      _queryToExecute += ' CASCADE;'
 
       // Clean table
       database.query(_queryToExecute, callback)


### PR DESCRIPTION
To delete tables with foreign keys, the "cascade" has to be added, it occurs to me when I am using timescale hypertables.