### PR TITLE
Fix regex for verifying mails

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -202,7 +202,7 @@ const validation = {
 
     const typeRegex = [{
       type: 'mail',
-      regex: '^\\w+([\\.-]?\\w+)*@\\w+([\\.-]?\\w+)*(\\.\\w{2,3})+$',
+      regex: '^[a-zA-Z0-9.+_-]+@\w+([\.-]?\w+)*(\.\w{2,3})+$',
       errMessage: 'is an invalid mail.'
     }, {
       type: 'phone',

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -202,7 +202,7 @@ const validation = {
 
     const typeRegex = [{
       type: 'mail',
-      regex: '^[a-zA-Z0-9.+_-]+@\w+([\.-]?\w+)*(\.\w{2,3})+$',
+      regex: '^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-.]+\\.[a-zA-Z0-9-.]{2,20}$',
       errMessage: 'is an invalid mail.'
     }, {
       type: 'phone',


### PR DESCRIPTION
Now it is possible to verify mails with tags, such as:
- test+lalalal@gmail.com

Or verify mails with long domains, such as:
- test+@enterprise.accountant 